### PR TITLE
tiny fix for trello DOM changes

### DIFF
--- a/source/card.js
+++ b/source/card.js
@@ -414,7 +414,7 @@ function addCardCommentHelp() {
 				    }
 				    else if (g_optEnterSEByComment.IsEnabled() && g_optEnterSEByComment.rgKeywords.length > 0) {
 				        var kw = g_optEnterSEByComment.getDefaultKeyword();
-				        help = setSmallFont($("<A class='quiet-button left' style='margin-left:10px' href='http://plusfortrello.blogspot.com/2014/12/plus-for-trello-se-card-comment-format.html' target='_blank'><b>" + kw + "</b> keyword help</A>").addClass(classSpentCommentHelp), 0.85);
+				        help = setSmallFont($("<A class='quiet-button u-float-left' style='margin-left:10px' href='http://plusfortrello.blogspot.com/2014/12/plus-for-trello-se-card-comment-format.html' target='_blank'><b>" + kw + "</b> keyword help</A>").addClass(classSpentCommentHelp), 0.85);
 				        help.prop("title", kw + " 0/4  :  adds 4 to your estimate\n\n\
 " + kw + " -2d 5/3 fix doc : adds 2days ago 5/3 with note 'fix doc'\n\n\
 " + kw + " @john 0/6 : adds to john 6 estimate\n\n\


### PR DESCRIPTION
 Trello changed the former 'left' class for floating left, and it is now called 'u-float-left'.
